### PR TITLE
Reduced copies, improved non-ascii support.

### DIFF
--- a/src/tegen.rs
+++ b/src/tegen.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use rand::{prelude::ThreadRng, Rng};
 
 /// The `TextGenerator` struct, used for generating text from a template.
@@ -27,17 +29,19 @@ impl TextGenerator {
     /// A template starts with `{` and ends with `}` and can contain `|` characters to separate different options.
     /// For example, `{Hello|Salutations}, {World|Reality}!`
     pub fn generate(&self, text: &str) -> String {
-        self.scan_and_replace(text)
+        let mut rng = rand::thread_rng();
+        self.scan_and_replace(text.into(), &mut rng).into_owned()
     }
 
-    fn get_random_part(&self, text: &str, rng: &mut ThreadRng) -> String {
+    /// Given text of a template without outer brackets, chooses and returns one of template's options.
+    fn get_random_part<'a>(&self, text: &'a str, rng: &mut ThreadRng) -> &'a str {
         let mut open_level = 0;
         let mut last_pos = 0;
         let mut is_ignore = false;
 
-        let mut parts = Vec::<String>::with_capacity(text.len());
+        let mut parts = Vec::<&'a str>::new();
 
-        for (i, c) in text.chars().enumerate() {
+        for (i, c) in text.char_indices() {
             if c == self.start_c {
                 open_level += 1;
                 is_ignore = true;
@@ -57,17 +61,17 @@ impl TextGenerator {
             }
 
             if c == self.sep {
-                parts.push(text[last_pos..i].to_string());
+                parts.push(&text[last_pos..i]);
                 last_pos = i + 1;
             }
         }
 
-        parts.push(text[last_pos..].to_string());
+        parts.push(&text[last_pos..]);
         let rng = rng.gen_range(0..parts.len());
-        parts[rng].clone()
+        parts[rng]
     }
 
-    fn scan_and_replace(&self, text: &str) -> String {
+    fn scan_and_replace<'a>(&self, text: Cow<'a, str>, rng: &mut ThreadRng) -> Cow<'a, str> {
         let mut start_safe_pos = 0;
         let mut start_pos = 0;
         let mut end_pos = 0;
@@ -76,9 +80,7 @@ impl TextGenerator {
 
         let mut result = String::new();
 
-        // Create rng here, so there isn't a random number generator constructed every call to get_random_part.
-        let mut rng = rand::thread_rng();
-        for (i, c) in text.chars().enumerate() {
+        for (i, c) in text.char_indices() {
             if c == self.start_c {
                 if open_level == 0 {
                     start_pos = i;
@@ -97,19 +99,75 @@ impl TextGenerator {
 
                     start_safe_pos = end_pos + 1;
 
-                    result.push_str(&self.scan_and_replace(
-                        &self.get_random_part(&text[(start_pos + 1)..end_pos], &mut rng),
-                    ));
+                    let template_slice = &text[(start_pos + 1)..end_pos];
+                    let text_choice = self.get_random_part(template_slice, rng);
+                    result.push_str(&self.scan_and_replace(text_choice.into(), rng));
                 }
                 continue;
             }
         }
 
         if !is_find {
-            return text.to_string();
+            return text;
         }
         result.push_str(&text[(end_pos + 1)..]);
 
-        result
+        Cow::Owned(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_template() {
+        let strings = vec![
+            "hello world",
+            "",
+            "a",
+            "123",
+            "{no closing",
+            "no opening}",
+            "}{",
+            "{",
+            "}",
+            "{{{{{{{{{{{{{{{",
+            "|",
+        ];
+
+        for expected in strings {
+            let result = TextGenerator::new().generate(expected);
+            assert_eq!(result, expected);
+        }
+    }
+
+    #[test]
+    fn simple_single_template() {
+        let template = "{hello}";
+        let expected = "hello";
+        let result = TextGenerator::new().generate(template);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn simple_single_template_special_character() {
+        let template = "{y̆es}";
+        let expected = "y̆es";
+        let result = TextGenerator::new().generate(template);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn general_deterministic_templates() {
+        let template_expected_pairs = vec![
+            ("Hello", "Hello"),
+            ("{}", ""),
+            ("Before {During} After\n ", "Before During After\n "),
+        ];
+        for (template, expected) in template_expected_pairs {
+            let result = TextGenerator::new().generate(template);
+            assert_eq!(result, expected);
+        }
     }
 }


### PR DESCRIPTION
Hello, I saw your crate and thought I might use it sometime. Please feel free to do anything you like with the code in this PR.

Changes:

- Reduced copies in `get_random_part` to instead use &str.
- I noticed non-ascii strings may be cut short such as "y̆es". Changed `chars().enumerate()` to use `char_indices` to consider the special char size.
- Added a couple tests.

Notes:

- Generally ran faster in benchmarks on my system.
- Unsure about exact behavior you are looking for, so some tests may be wrong (like empty template?).
- Did not run fuzzers.

Cheers!